### PR TITLE
aesCtrDecrypt with fallback for older servers

### DIFF
--- a/packages/backend/src/services/crypto/aes.ts
+++ b/packages/backend/src/services/crypto/aes.ts
@@ -315,3 +315,51 @@ export function aesCfbEncrypt(
 
   return ciphertext;
 }
+
+/**
+ * AES-256-CTR decryption/encryption
+ * Note: In CTR mode, encryption and decryption are identical operations.
+ * We encrypt the counter to generate a keystream, then XOR with input.
+ */
+export function aesCtrDecrypt(
+  key: Uint8Array,
+  iv: Uint8Array,
+  data: Uint8Array,
+): Uint8Array {
+  if (key.length !== 32) {
+    throw new Error("AES-256 requires a 32-byte key");
+  }
+  if (iv.length !== 16) {
+    throw new Error("AES requires a 16-byte IV");
+  }
+
+  const roundKeys = keyExpansion(key);
+  const output = new Uint8Array(data.length);
+  
+  // Clone IV to create the initial counter block
+  const counter = new Uint8Array(iv);
+
+  for (let i = 0; i < data.length; i += 16) {
+    // 1. Generate keystream by encrypting the counter
+    const keystream = aesEncryptBlock(counter, roundKeys);
+
+    // 2. XOR keystream with data (plaintext or ciphertext)
+    const blockSize = Math.min(16, data.length - i);
+    for (let j = 0; j < blockSize; j++) {
+      output[i + j] = data[i + j]! ^ keystream[j]!;
+    }
+
+    // 3. Increment Counter (Standard 128-bit Big Endian Increment)
+    // We start at the last byte and move backwards
+    for (let k = 15; k >= 0; k--) {
+      if (counter[k] === 255) {
+        counter[k] = 0; // Wrap around and carry over to next byte
+      } else {
+        counter[k]!++;
+        break; // No carry over, stop incrementing
+      }
+    }
+  }
+
+  return output;
+}

--- a/packages/backend/src/services/crypto/index.ts
+++ b/packages/backend/src/services/crypto/index.ts
@@ -165,12 +165,16 @@ export function decryptMessage(key: string, secureMessage: string): string {
     throw new Error("Keys not initialized. Call initializeRSAKeys() first.");
   }
 
+// FIX 1: Sanitize the incoming message string
+  // Remove all newlines, spaces, and tabs before processing
+  const cleanMessage = secureMessage.replace(/[\r\n\s]+/g, '');
+
   // Step 1: Decrypt the AES key using RSA-OAEP
   const encryptedKeyBytes = base64ToUint8Array(key);
   const decryptedKey = rsaOaepDecrypt(encryptedKeyBytes, keyPair.privateKey);
 
-  // Step 2: Decode the secure message from base64
-  const secureMessageBuffer = base64ToUint8Array(secureMessage);
+  // Step 2: Decode the secure message from base64 (USING CLEAN STRING)
+  const secureMessageBuffer = base64ToUint8Array(cleanMessage);
 
   // Step 3: Extract IV (first 16 bytes) and ciphertext (rest)
   const iv = secureMessageBuffer.slice(0, 16);

--- a/packages/backend/src/services/crypto/index.ts
+++ b/packages/backend/src/services/crypto/index.ts
@@ -6,7 +6,7 @@
 import { Buffer } from "buffer";
 import { randomBytes } from "crypto";
 
-import { aesCfbDecrypt } from "./aes";
+import { aesCfbDecrypt, aesCtrDecrypt } from "./aes";
 import {
   base64ToUint8Array,
   exportPublicKeyPEM,
@@ -194,10 +194,23 @@ export function decryptMessage(key: string, secureMessage: string): string {
     aesKey = decryptedKey.slice(0, 32);
   }
 
-  const decrypted = aesCfbDecrypt(aesKey, iv, ciphertext);
+// Attempt 1: Try AES-CTR (New Servers)
+  try {
+    const decryptedCtr = aesCtrDecrypt(aesKey, iv, ciphertext);
+    const ctrString = uint8ArrayToString(decryptedCtr);
+    
+    // Validate: If it parses as JSON, return it immediately
+    
+    JSON.parse(ctrString); 
+    
+    return ctrString;
+  } catch (e) {
+    // This throws if the decryption was garbage that can't be parsed as JSON, which is likely the case for old servers using AES-CFB
+}
 
-  // Convert to UTF-8 string
-  return uint8ArrayToString(decrypted);
+  // Attempt 2: Fallback to AES-CFB (Old Servers)
+  const decryptedCfb = aesCfbDecrypt(aesKey, iv, ciphertext);
+  return uint8ArrayToString(decryptedCfb);
 }
 
 /**


### PR DESCRIPTION
Problem:
Interactions  from Interactsh version 1.3.0 failing to show up in Caido. 

Error Message:
Failed to decrypt/parse interaction: SyntaxError: Bad Control character in string literal in JSON at position 22

Solution:
Add aesCtrDecrypt method and include fallback to aesCfbDecrypt to maintain compatibility with older versions