### PR TITLE
Fix readFile to not rely on error message

### DIFF
--- a/packages/backend/src/__tests__/mockFs.ts
+++ b/packages/backend/src/__tests__/mockFs.ts
@@ -7,13 +7,16 @@ export function createMockFs() {
   fileSystem.clear();
 
   return {
-    readFile: vi.fn((path: string) => {
-      const content = fileSystem.get(path);
-      if (content === undefined) {
+    access: vi.fn((path: string) => {
+      if (!fileSystem.has(path)) {
         const err = new Error(`ENOENT: ${path}`) as Error & { code: string };
         err.code = "ENOENT";
         return Promise.reject(err);
       }
+      return Promise.resolve();
+    }),
+    readFile: vi.fn((path: string) => {
+      const content = fileSystem.get(path);
       return Promise.resolve(content);
     }),
     writeFile: vi.fn((path: string, data: string) => {

--- a/packages/backend/src/stores/baseStorage.ts
+++ b/packages/backend/src/stores/baseStorage.ts
@@ -26,6 +26,9 @@ async function exists(filePath: string): Promise<boolean> {
 }
 
 export async function readJson<T>(filePath: string): Promise<T | undefined> {
+  // We can't use an ENOENT error check since
+  // we are not in a true node vm and the error
+  // returned by quickjs are not normalized
   if (!(await exists(filePath))) {
     return undefined;
   }

--- a/packages/backend/src/stores/baseStorage.ts
+++ b/packages/backend/src/stores/baseStorage.ts
@@ -1,4 +1,12 @@
-import { mkdir, readdir, readFile, rename, rm, writeFile } from "fs/promises";
+import {
+  access,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "fs/promises";
 import path from "path";
 
 import { requireSDK } from "../sdk";
@@ -8,16 +16,22 @@ export function getBasePath(): string {
   return sdk.meta.path();
 }
 
-export async function readJson<T>(filePath: string): Promise<T | undefined> {
+async function exists(filePath: string): Promise<boolean> {
   try {
-    const data = await readFile(filePath, "utf-8");
-    return JSON.parse(data) as T;
-  } catch (error) {
-    if ((error as { code?: string }).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
   }
+}
+
+export async function readJson<T>(filePath: string): Promise<T | undefined> {
+  if (!(await exists(filePath))) {
+    return undefined;
+  }
+
+  const data = await readFile(filePath, "utf-8");
+  return JSON.parse(data) as T;
 }
 
 export async function writeJson<T>(filePath: string, data: T): Promise<void> {


### PR DESCRIPTION
This is not a node vm, we cant rely on that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined storage file-read flow to perform an early existence check and skip unnecessary reads/parsing, preserving current user-visible behavior.
* **Tests**
  * Updated test mocks to simulate filesystem access behavior more accurately, including access failures for missing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->